### PR TITLE
fix: correct inheritance fields issue

### DIFF
--- a/src/main/java/fr/ouestfrance/querydsl/service/scanner/FilterFieldAnnotationScanner.java
+++ b/src/main/java/fr/ouestfrance/querydsl/service/scanner/FilterFieldAnnotationScanner.java
@@ -43,36 +43,36 @@ public class FilterFieldAnnotationScanner {
 
         List<FilterFieldViolation> violations = new ArrayList<>();
 
-        Arrays.stream(clazz.getDeclaredFields())
+        getAllFields(clazz).stream()
                 .filter(this::hasFilterFieldAnnotation)
                 .forEach(
-                field -> {
-                     FilterFields filterFields = field.getAnnotation(FilterFields.class);
-                    List<FilterField> groupFilters = new ArrayList<>();
-                    if (filterFields!= null && !filterFields.groupName().isEmpty()) {
-                        groupFilters.addAll(Arrays.stream(filterFields.value()).toList());
-                        GroupFilter filterAndGroup = new GroupFilter(UUID.randomUUID().toString(), new ArrayList<>(), GroupFilter.Operand.AND);
-                        Arrays.stream(filterFields.value())
-                                .forEach(filterField -> {
-                                    SimpleFilter filter = new SimpleFilter(firstNotEmpty(filterField.key(), field.getName()), filterField.operation(), filterField.orNull(), field);
-                                    validatorService.validate(filter).ifPresent(violations::add);
-                                    filterAndGroup.filters().add(filter);
-                                });
-                        appendToGroup(rootGroup, filterFields.groupName(), filterAndGroup);
-                    }
-
-                    // On filterField
-                    Arrays.stream(field.getAnnotationsByType(FilterField.class))
-                            .filter(x-> !groupFilters.contains(x))
-                            .forEach(
-                            filterField -> {
-                                SimpleFilter filter = new SimpleFilter(firstNotEmpty(filterField.key(), field.getName()), filterField.operation(), filterField.orNull(), field);
-                                validatorService.validate(filter).ifPresent(violations::add);
-                                appendToGroup(rootGroup, filterField.groupName(), filter);
+                        field -> {
+                            FilterFields filterFields = field.getAnnotation(FilterFields.class);
+                            List<FilterField> groupFilters = new ArrayList<>();
+                            if (filterFields != null && !filterFields.groupName().isEmpty()) {
+                                groupFilters.addAll(Arrays.stream(filterFields.value()).toList());
+                                GroupFilter filterAndGroup = new GroupFilter(UUID.randomUUID().toString(), new ArrayList<>(), GroupFilter.Operand.AND);
+                                Arrays.stream(filterFields.value())
+                                        .forEach(filterField -> {
+                                            SimpleFilter filter = new SimpleFilter(firstNotEmpty(filterField.key(), field.getName()), filterField.operation(), filterField.orNull(), field);
+                                            validatorService.validate(filter).ifPresent(violations::add);
+                                            filterAndGroup.filters().add(filter);
+                                        });
+                                appendToGroup(rootGroup, filterFields.groupName(), filterAndGroup);
                             }
-                    );
-                }
-        );
+
+                            // On filterField
+                            Arrays.stream(field.getAnnotationsByType(FilterField.class))
+                                    .filter(x -> !groupFilters.contains(x))
+                                    .forEach(
+                                            filterField -> {
+                                                SimpleFilter filter = new SimpleFilter(firstNotEmpty(filterField.key(), field.getName()), filterField.operation(), filterField.orNull(), field);
+                                                validatorService.validate(filter).ifPresent(violations::add);
+                                                appendToGroup(rootGroup, filterField.groupName(), filter);
+                                            }
+                                    );
+                        }
+                );
 
         // Check for violations
         if (!violations.isEmpty()) {
@@ -83,9 +83,10 @@ public class FilterFieldAnnotationScanner {
 
     /**
      * Append a filter to a groupName, if no group found, it will compute a new OR Group
+     *
      * @param rootGroup root group
      * @param groupName name of the searched group
-     * @param filter filter to append
+     * @param filter    filter to append
      */
     private void appendToGroup(GroupFilter rootGroup, String groupName, Filter filter) {
         if (groupName.isEmpty()) {
@@ -103,6 +104,7 @@ public class FilterFieldAnnotationScanner {
 
     /**
      * Retrieve a rootGroup by its name
+     *
      * @param rootGroup rootGroup
      * @param groupName name of the searched rootGroup
      * @return optional rootGroup
@@ -113,6 +115,22 @@ public class FilterFieldAnnotationScanner {
                 .map(GroupFilter.class::cast)
                 .filter(filterGroup -> groupName.equals(filterGroup.name()))
                 .findFirst();
+    }
+
+    /**
+     * Collect all fields from the class hierarchy (class + all superclasses up to Object)
+     *
+     * @param clazz class to inspect
+     * @return list of all declared fields
+     */
+    private List<Field> getAllFields(Class<?> clazz) {
+        List<Field> fields = new ArrayList<>();
+        Class<?> current = clazz;
+        while (current != null && current != Object.class) {
+            fields.addAll(Arrays.asList(current.getDeclaredFields()));
+            current = current.getSuperclass();
+        }
+        return fields;
     }
 
     /**

--- a/src/test/java/fr/ouestfrance/querydsl/dummy/DummyRequestWithInheritance.java
+++ b/src/test/java/fr/ouestfrance/querydsl/dummy/DummyRequestWithInheritance.java
@@ -1,0 +1,14 @@
+package fr.ouestfrance.querydsl.dummy;
+
+import fr.ouestfrance.querydsl.FilterField;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class DummyRequestWithInheritance extends DummyRequest {
+
+    @FilterField(key = "anotherProductCode")
+    private String anotherCode;
+}
+

--- a/src/test/java/fr/ouestfrance/querydsl/service/scanner/FilterFieldAnnotationScannerTest.java
+++ b/src/test/java/fr/ouestfrance/querydsl/service/scanner/FilterFieldAnnotationScannerTest.java
@@ -2,9 +2,9 @@ package fr.ouestfrance.querydsl.service.scanner;
 
 import fr.ouestfrance.querydsl.dummy.DummyRequest;
 import fr.ouestfrance.querydsl.dummy.DummyRequestOrGroupMultipleField;
+import fr.ouestfrance.querydsl.dummy.DummyRequestWithInheritance;
 import fr.ouestfrance.querydsl.model.Filter;
 import fr.ouestfrance.querydsl.model.GroupFilter;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -15,18 +15,26 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 class FilterFieldAnnotationScannerTest {
 
     private final FilterFieldAnnotationScanner scanner = new FilterFieldAnnotationScanner();
+
     @Test
-    void shouldScanModel(){
+    void shouldScanModel() {
         List<Filter> scan = scanner.scan(DummyRequest.class);
         assertNotNull(scan);
         assertEquals(6, scan.size());
     }
 
     @Test
-    void shouldScanGroupMultiFieldModel(){
+    void shouldScanGroupMultiFieldModel() {
         List<Filter> scan = scanner.scan(DummyRequestOrGroupMultipleField.class);
         assertNotNull(scan);
         assertEquals(1, scan.size());
         assertEquals(1, scan.stream().filter(GroupFilter.class::isInstance).count());
+    }
+
+    @Test
+    void shouldScanInheritanceFieldsModel() {
+        List<Filter> scan = scanner.scan(DummyRequestWithInheritance.class);
+        assertNotNull(scan);
+        assertEquals(7, scan.size());
     }
 }


### PR DESCRIPTION
## Summary

- `FilterFieldAnnotationScanner` scannait uniquement les champs déclarés directement sur la classe (`getDeclaredFields()`), ignorant les champs hérités des classes parentes
- Ajout de `getAllFields()` qui remonte la hiérarchie de classes jusqu'à `Object`
- Ajout de `DummyRequestWithInheritance` (extend `DummyRequest` + 1 champ) et du test `shouldScanInheritanceFieldsModel` qui vérifie les 7 filtres (6 du parent + 1 hérité)

## Test plan

- [ ] `shouldScanInheritanceFieldsModel` : vérifie que 7 filtres sont retournés pour une classe héritée
- [ ] `shouldScanModel` et `shouldScanGroupMultiFieldModel` : non-régression

🤖 Generated with [Claude Code](https://claude.com/claude-code)