### PR TITLE
fix: replace HashMap with ConcurrentHashMap to fix ConcurrentModificationException

### DIFF
--- a/src/main/java/fr/ouestfrance/querydsl/service/validators/FilterFieldValidatorService.java
+++ b/src/main/java/fr/ouestfrance/querydsl/service/validators/FilterFieldValidatorService.java
@@ -4,9 +4,9 @@ import fr.ouestfrance.querydsl.FilterOperation;
 import fr.ouestfrance.querydsl.model.SimpleFilter;
 
 import java.lang.reflect.InvocationTargetException;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * FilterFieldValidator service allow to check the validity of annotated clazz
@@ -37,7 +37,7 @@ public class FilterFieldValidatorService {
     /**
      * Map of validators
      */
-    private static final Map<Class<? extends FilterFieldValidator>, FilterFieldValidator> VALIDATOR_MAP = new HashMap<>();
+    private static final Map<Class<? extends FilterFieldValidator>, FilterFieldValidator> VALIDATOR_MAP = new ConcurrentHashMap<>();
 
     /**
      * Check each filter and build a filter of violations


### PR DESCRIPTION
## Summary

- `FilterFieldValidatorService.VALIDATOR_MAP` était un `HashMap` statique accédé par plusieurs threads via `computeIfAbsent`
- `HashMap` n'est pas thread-safe : en contexte concurrent, `computeIfAbsent` peut lever une `ConcurrentModificationException`
- Remplacement par `ConcurrentHashMap` dont `computeIfAbsent` est atomique

## Root cause

```
java.util.ConcurrentModificationException
at java.base/java.util.HashMap.computeIfAbsent
at FilterFieldValidatorService.getValidator(FilterFieldValidatorService.java:68)
```

## Test plan

- [ ] Vérifier que les tests unitaires existants passent
- [ ] Tester en charge avec plusieurs appels `search()` simultanés